### PR TITLE
Update zip dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ tar = { version = "0.4", optional = true }
 xz2 = { version = "0.1", optional = true }
 
 [dependencies.zip]
-version = "0.5"
+version = "0.6"
 default-features = false
 features = ["deflate", "time"]
 optional = true


### PR DESCRIPTION
The time library of zip in the old version has a vulnerability so it fails `cargo audit`.